### PR TITLE
ratbot workflow: replace `scc` with `tokei`

### DIFF
--- a/.github/workflows/ratbot.yml
+++ b/.github/workflows/ratbot.yml
@@ -9,28 +9,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get the lines of code
-        id: scc
-        uses: iryanbell/scc-docker-action@v1.0.2 
-        with:
-          args: ${{ env.workspace }} -irs 
-
-      - name: Write output to a file
+      - name: Install Rust and Cargo
         run: |
-          echo "${{ steps.scc.outputs.scc }}" > scc_output.txt
+          curl -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+
+      - name: Install Tokei
+        run: cargo install tokei
+
+      - name: Run Tokei and get the lines of code
+        run: tokei crates/ratchet-core > tokei_output.txt
 
       - name: Comment or Update PR
         uses: actions/github-script@v6
         with:
           script: |
             const fs = require('fs');
-            const sccOutput = fs.readFileSync('scc_output.txt', 'utf8');
+            const tokeiOutput = fs.readFileSync('tokei_output.txt', 'utf8');
             const uniqueIdentifier = 'Code Metrics Report'; 
             const codeReport = `
               <details>
               <summary>${uniqueIdentifier}</summary>
               <pre>
-              ${sccOutput}
+              ${tokeiOutput}
               </pre>
               </details>
             `;


### PR DESCRIPTION
A GitHub Action supporting `scc` for code metrics appear to have disappeared causing the ratbot GitHub Action flow to fail.

This PR replaces `scc` with a slightly more popular tool `tokei` which meets the same objective.

Fixes #198.