### PR TITLE
Introduce `device_limits` and `device_features` inside `WgpuDevice` to store a subset of `wgpu::Limits` and `wgpu::Features`

### DIFF
--- a/crates/ratchet-core/src/gpu/device.rs
+++ b/crates/ratchet-core/src/gpu/device.rs
@@ -252,13 +252,15 @@ impl From<wgpu::Limits> for DeviceLimits {
 
 #[derive(Clone)]
 pub struct DeviceFeatures {
-    pub SHADER_F16: u32,
+    pub SHADER_F16: u64,
+    pub SUBGROUP_COMPUTE: u64
 }
 
 impl From<wgpu::Features> for DeviceFeatures {
     fn from(features: wgpu::Features) -> Self {
         DeviceFeatures {
-            SHADER_F16: features.contains(wgpu::Features::SHADER_F16) as u32,
+            SHADER_F16: features.contains(wgpu::Features::SHADER_F16) as u64,
+            SUBGROUP_COMPUTE: features.contains(wgpu::Features::SUBGROUP) as u64
         }
     }
 }

--- a/crates/ratchet-core/src/gpu/device.rs
+++ b/crates/ratchet-core/src/gpu/device.rs
@@ -24,6 +24,7 @@ pub struct WgpuDevice {
     bind_group_layout_pool: Arc<BindGroupLayoutPool>,
     pipeline_layout_pool: Arc<PipelineLayoutPool>,
     compute_pipeline_pool: Arc<ComputePipelinePool>,
+    device_limits: DeviceLimits,
 }
 
 impl std::ops::Deref for WgpuDevice {
@@ -82,6 +83,8 @@ impl WgpuDevice {
         }?;
         log::info!("Device: {:?}", device.limits());
 
+        let limits = DeviceLimits::from(device.limits());
+
         Ok(Self {
             queue: Arc::new(queue),
             ordinal: 0,
@@ -91,6 +94,7 @@ impl WgpuDevice {
             pipeline_layout_pool: Arc::new(PipelineLayoutPool::new()),
             compute_pipeline_pool: Arc::new(ComputePipelinePool::new()),
             device: Arc::new(device),
+            device_limits: limits
         })
     }
 
@@ -223,5 +227,22 @@ impl WgpuDevice {
 
     pub fn begin_pass(&self) {
         self.buffer_allocator.begin_pass(0);
+    }
+}
+
+#[derive(Clone)]
+pub struct DeviceLimits {
+    pub max_bind_groups: u32,
+    pub max_storage_buffer_binding_size: u32,
+    pub max_compute_invocations_per_workgroup: u32,
+}
+
+impl From<wgpu::Limits> for DeviceLimits {
+    fn from(limits: wgpu::Limits) -> Self {
+        DeviceLimits {
+            max_bind_groups: limits.max_bind_groups,
+            max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size,
+            max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup,
+        }
     }
 }

--- a/crates/ratchet-core/src/gpu/device.rs
+++ b/crates/ratchet-core/src/gpu/device.rs
@@ -25,6 +25,7 @@ pub struct WgpuDevice {
     pipeline_layout_pool: Arc<PipelineLayoutPool>,
     compute_pipeline_pool: Arc<ComputePipelinePool>,
     device_limits: DeviceLimits,
+    device_features: DeviceFeatures,
 }
 
 impl std::ops::Deref for WgpuDevice {
@@ -84,6 +85,7 @@ impl WgpuDevice {
         log::info!("Device: {:?}", device.limits());
 
         let limits = DeviceLimits::from(device.limits());
+        let features = DeviceFeatures::from(device.features());
 
         Ok(Self {
             queue: Arc::new(queue),
@@ -94,7 +96,8 @@ impl WgpuDevice {
             pipeline_layout_pool: Arc::new(PipelineLayoutPool::new()),
             compute_pipeline_pool: Arc::new(ComputePipelinePool::new()),
             device: Arc::new(device),
-            device_limits: limits
+            device_limits: limits,
+            device_features: features,
         })
     }
 
@@ -243,6 +246,19 @@ impl From<wgpu::Limits> for DeviceLimits {
             max_bind_groups: limits.max_bind_groups,
             max_storage_buffer_binding_size: limits.max_storage_buffer_binding_size,
             max_compute_invocations_per_workgroup: limits.max_compute_invocations_per_workgroup,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DeviceFeatures {
+    pub SHADER_F16: u32,
+}
+
+impl From<wgpu::Features> for DeviceFeatures {
+    fn from(features: wgpu::Features) -> Self {
+        DeviceFeatures {
+            SHADER_F16: features.contains(wgpu::Features::SHADER_F16) as u32,
         }
     }
 }


### PR DESCRIPTION
Start storing a subset of `wgpu::Limits` on `Device`, so that we can start handling dispatch limits device-specifically.

Related #185 