### PR TITLE
ci: use pnpm/action-setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,9 +27,10 @@ runs:
       run: pip install -r requirements.txt
       shell: bash
 
-    - name: Enable node.js corepack
-      run: corepack enable
-      shell: bash
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        run_install: false
 
     - name: Setup node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
This should resolve the following error when running CI on Windows.

```
corepack enable
     |  ~~~~~~~~
     | The term 'corepack' is not recognized as a name of a cmdlet, function, script file, or executable program. Check
     | the spelling of the name, or if a path was included, verify that the path is correct and try again.
```