### PR TITLE
Feature/CPU init

### DIFF
--- a/crates/ratchet-core/src/cpu/mod.rs
+++ b/crates/ratchet-core/src/cpu/mod.rs
@@ -2,7 +2,7 @@ use crate::{CPUBuffer, OperationError, Storage, Tensor, TensorDType};
 use bytemuck::NoUninit;
 
 #[inline]
-fn apply_fn_helper<T: TensorDType, U: TensorDType>(src: &[T], dst: &mut [U], f: fn(T) -> U) {
+fn unary_apply_fn_helper<T: TensorDType, U: TensorDType>(src: &[T], dst: &mut [U], f: fn(T) -> U) {
     assert_eq!(src.len(), dst.len());
     for (s, d) in src.iter().copied().zip(dst.iter_mut()) {
         *d = f(s);
@@ -10,15 +10,71 @@ fn apply_fn_helper<T: TensorDType, U: TensorDType>(src: &[T], dst: &mut [U], f: 
 }
 
 #[inline]
-pub fn apply_fn<T: TensorDType, U: TensorDType>(
+pub fn unary_apply_fn<T: TensorDType, U: TensorDType>(
     input: &Tensor,
     dst: &Tensor,
     f: fn(T) -> U,
 ) -> Result<(), OperationError> {
     let input = input.to_vec::<T>()?;
-    let mut result = vec![U::zero(); dst.shape().numel()];
-    apply_fn_helper(&input, &mut result, f);
+    let mut result = Vec::with_capacity(dst.shape().numel());
+    unary_apply_fn_helper(&input, &mut result, f);
     cpu_store_result(dst, &result);
+    Ok(())
+}
+
+#[inline]
+fn binary_apply_fn_helper<T: TensorDType, U: TensorDType>(
+    lhs: &[T],
+    rhs: &[T],
+    dst: &mut [U],
+    f: fn(T, T) -> U,
+) {
+    assert_eq!(lhs.len(), dst.len());
+    assert_eq!(rhs.len(), dst.len());
+    for ((l, r), d) in lhs
+        .iter()
+        .copied()
+        .zip(rhs.iter().copied())
+        .zip(dst.iter_mut())
+    {
+        *d = f(l, r);
+    }
+}
+
+#[inline]
+fn binary_apply_inplace_helper<T: TensorDType>(lhs: &mut [T], rhs: &[T], f: fn(T, T) -> T) {
+    assert_eq!(lhs.len(), rhs.len());
+    lhs.iter_mut().zip(rhs.iter()).for_each(|(l, r)| {
+        *l = f(*l, *r);
+    });
+}
+
+#[inline]
+pub fn binary_apply_fn<T: TensorDType, U: TensorDType>(
+    lhs: &Tensor,
+    rhs: &Tensor,
+    dst: &Tensor,
+    f: fn(T, T) -> U,
+) -> Result<(), OperationError> {
+    let lhs = lhs.to_vec::<T>()?;
+    let rhs = rhs.to_vec::<T>()?;
+    let mut result = Vec::with_capacity(dst.shape().numel());
+    binary_apply_fn_helper(&lhs, &rhs, &mut result, f);
+    cpu_store_result(dst, &result);
+    Ok(())
+}
+
+#[inline]
+pub fn binary_apply_inplace<T: TensorDType>(
+    lhs: &Tensor,
+    rhs: &Tensor,
+    dst: &Tensor,
+    f: fn(T, T) -> T,
+) -> Result<(), OperationError> {
+    let mut lhs = lhs.to_vec::<T>()?;
+    let rhs = rhs.to_vec::<T>()?;
+    binary_apply_inplace_helper(&mut lhs, &rhs, f);
+    cpu_store_result(dst, &lhs);
     Ok(())
 }
 

--- a/crates/ratchet-core/src/cpu/mod.rs
+++ b/crates/ratchet-core/src/cpu/mod.rs
@@ -1,5 +1,129 @@
-use crate::{CPUBuffer, OperationError, Storage, Tensor, TensorDType};
+use crate::{
+    CPUBuffer, CPUOperation, DType, OpGuards, Operation, OperationError, RVec, Storage,
+    StorageView, Tensor, TensorDType, Unary, UnaryOp,
+};
 use bytemuck::NoUninit;
+use core::marker::PhantomData;
+use half::{bf16, f16};
+use num_traits::Float;
+
+#[derive(Debug)]
+pub struct CPU<T: TensorDType, OP: Operation> {
+    op: OP,
+    dtype: PhantomData<T>,
+}
+
+impl<T: TensorDType, OP: Operation> CPU<T, OP> {
+    pub fn new(op: OP) -> Self {
+        Self {
+            op,
+            dtype: PhantomData,
+        }
+    }
+}
+
+impl<T: TensorDType, OP: Operation> OpGuards for CPU<T, OP> {
+    fn check_shapes(&self) {
+        self.op.check_shapes();
+    }
+
+    fn check_dtypes(&self) {
+        self.op.check_dtypes();
+    }
+}
+
+impl<T: TensorDType, OP: Operation> Operation for CPU<T, OP> {
+    fn name(&self) -> &'static str {
+        self.op.name()
+    }
+
+    fn compute_view(&self) -> Result<StorageView, OperationError> {
+        self.op.compute_view()
+    }
+
+    fn srcs(&self) -> RVec<&Tensor> {
+        self.op.srcs()
+    }
+}
+
+macro_rules! impl_cpu_unary_op {
+    ($method_name:ident, $op:expr) => {
+        fn $method_name(input: &Tensor, dst: Tensor) -> Result<Tensor, OperationError> {
+            unary_apply_fn(input, &dst, $op)?;
+            Ok(dst)
+        }
+    };
+}
+
+macro_rules! impl_cpu_unary_wrapper {
+    ($dtype:ident, $conv:expr) => {
+        impl CPU<$dtype, Unary> {
+            impl_cpu_unary_op!(gelu, |x: $dtype| $conv(0.5)
+                * x
+                * ($conv(1.0)
+                    + $dtype::tanh(
+                        $conv(0.797_884_6) * x * ($conv(1.0) + $conv(0.044715) * x * x)
+                    )));
+
+            impl_cpu_unary_op!(tanh, |x: $dtype| x.tanh());
+            impl_cpu_unary_op!(exp, |x: $dtype| x.exp());
+            impl_cpu_unary_op!(log, |x: $dtype| x.ln());
+            impl_cpu_unary_op!(sin, |x: $dtype| x.sin());
+            impl_cpu_unary_op!(cos, |x: $dtype| x.cos());
+            impl_cpu_unary_op!(abs, |x: $dtype| x.abs());
+            impl_cpu_unary_op!(sqrt, |x: $dtype| x.sqrt());
+            impl_cpu_unary_op!(relu, |x: $dtype| x.max($conv(0.0)));
+            impl_cpu_unary_op!(floor, |x: $dtype| x.floor());
+            impl_cpu_unary_op!(ceil, |x: $dtype| x.ceil());
+            impl_cpu_unary_op!(neg, |x: $dtype| -x);
+            impl_cpu_unary_op!(silu, |x: $dtype| x / ($conv(1.0) + (-x).exp()));
+            impl_cpu_unary_op!(sigmoid, |x: $dtype| $conv(1.0) / ($conv(1.0) + (-x).exp()));
+        }
+    };
+}
+
+macro_rules! impl_cpu_unary {
+    ($dtype:ident) => {
+        impl_cpu_unary!($dtype, |x| x);
+    };
+    ($dtype:ident, $conv:expr) => {
+        impl_cpu_unary_wrapper!($dtype, $conv);
+
+        impl CPUOperation for CPU<$dtype, Unary> {
+            fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+                match self.op.op() {
+                    UnaryOp::Gelu => Self::gelu(self.op.input(), dst),
+                    UnaryOp::Tanh => Self::tanh(self.op.input(), dst),
+                    UnaryOp::Exp => Self::exp(self.op.input(), dst),
+                    UnaryOp::Log => Self::log(self.op.input(), dst),
+                    UnaryOp::Sin => Self::sin(self.op.input(), dst),
+                    UnaryOp::Cos => Self::cos(self.op.input(), dst),
+                    UnaryOp::Abs => Self::abs(self.op.input(), dst),
+                    UnaryOp::Sqrt => Self::sqrt(self.op.input(), dst),
+                    UnaryOp::Relu => Self::relu(self.op.input(), dst),
+                    UnaryOp::Floor => Self::floor(self.op.input(), dst),
+                    UnaryOp::Ceil => Self::ceil(self.op.input(), dst),
+                    UnaryOp::Neg => Self::neg(self.op.input(), dst),
+                    UnaryOp::Silu => Self::silu(self.op.input(), dst),
+                    UnaryOp::Sigmoid => Self::sigmoid(self.op.input(), dst),
+                }
+            }
+        }
+    };
+}
+
+impl_cpu_unary!(f32);
+impl_cpu_unary!(f16, f16::from_f32);
+impl_cpu_unary!(bf16, bf16::from_f32);
+
+pub fn apply_unary(unary: Unary, dst: Tensor) -> Result<Tensor, OperationError> {
+    match dst.dt() {
+        DType::F32 => CPU::<f32, _>::new(unary).apply(dst),
+        DType::F16 => CPU::<f16, _>::new(unary).apply(dst),
+        DType::BF16 => CPU::<bf16, _>::new(unary).apply(dst),
+        _ => todo!(),
+    }
+}
 
 #[inline]
 fn unary_apply_fn_helper<T: TensorDType, U: TensorDType>(src: &[T], dst: &mut [U], f: fn(T) -> U) {
@@ -16,7 +140,7 @@ pub fn unary_apply_fn<T: TensorDType, U: TensorDType>(
     f: fn(T) -> U,
 ) -> Result<(), OperationError> {
     let input = input.to_vec::<T>()?;
-    let mut result = Vec::with_capacity(dst.shape().numel());
+    let mut result = vec![U::zero(); dst.shape().numel()];
     unary_apply_fn_helper(&input, &mut result, f);
     cpu_store_result(dst, &result);
     Ok(())
@@ -58,7 +182,7 @@ pub fn binary_apply_fn<T: TensorDType, U: TensorDType>(
 ) -> Result<(), OperationError> {
     let lhs = lhs.to_vec::<T>()?;
     let rhs = rhs.to_vec::<T>()?;
-    let mut result = Vec::with_capacity(dst.shape().numel());
+    let mut result = vec![U::zero(); dst.shape().numel()];
     binary_apply_fn_helper(&lhs, &rhs, &mut result, f);
     cpu_store_result(dst, &result);
     Ok(())

--- a/crates/ratchet-core/src/cpu/mod.rs
+++ b/crates/ratchet-core/src/cpu/mod.rs
@@ -1,0 +1,27 @@
+use crate::{CPUBuffer, OperationError, Storage, Tensor, TensorDType};
+use bytemuck::NoUninit;
+
+#[inline]
+fn apply_fn_helper<T: TensorDType, U: TensorDType>(src: &[T], dst: &mut [U], f: fn(T) -> U) {
+    assert_eq!(src.len(), dst.len());
+    for (s, d) in src.iter().copied().zip(dst.iter_mut()) {
+        *d = f(s);
+    }
+}
+
+#[inline]
+pub fn apply_fn<T: TensorDType, U: TensorDType>(
+    input: &Tensor,
+    dst: &Tensor,
+    f: fn(T) -> U,
+) -> Result<(), OperationError> {
+    let input = input.to_vec::<T>()?;
+    let mut result = vec![U::zero(); dst.shape().numel()];
+    apply_fn_helper(&input, &mut result, f);
+    cpu_store_result(dst, &result);
+    Ok(())
+}
+
+pub fn cpu_store_result<T: NoUninit>(dst: &Tensor, data: &[T]) {
+    dst.update_storage(Storage::CPU(CPUBuffer::from_slice(data, dst.shape())));
+}

--- a/crates/ratchet-core/src/lib.rs
+++ b/crates/ratchet-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 mod compiled_op;
+mod cpu;
 mod device;
 mod dtype;
 mod enforcer;
@@ -17,6 +18,7 @@ mod tensor;
 mod tensor_id;
 
 pub use compiled_op::*;
+pub use cpu::*;
 pub use device::*;
 pub use dtype::*;
 pub use enforcer::*;

--- a/crates/ratchet-core/src/op.rs
+++ b/crates/ratchet-core/src/op.rs
@@ -366,7 +366,3 @@ pub trait GPUOperation: Operation {
 pub trait CPUOperation: Operation {
     fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError>;
 }
-
-pub(crate) fn cpu_store_result<T: NoUninit>(dst: &Tensor, data: &[T]) {
-    dst.update_storage(Storage::CPU(CPUBuffer::from_slice(data, dst.shape())));
-}

--- a/crates/ratchet-core/src/op.rs
+++ b/crates/ratchet-core/src/op.rs
@@ -3,9 +3,10 @@ use crate::gpu::{
     PoolError, WgpuDevice,
 };
 use crate::{
-    ops::*, rvec, CompiledOp, InvariantError, Kernel, KernelBuildError, KernelMetadata,
-    KernelModuleDesc, RVec, StorageView, Tensor, WgslFragment, WorkgroupSize,
+    ops::*, rvec, CPUBuffer, CompiledOp, InvariantError, Kernel, KernelBuildError, KernelMetadata,
+    KernelModuleDesc, RVec, Storage, StorageView, Tensor, WgslFragment, WorkgroupSize,
 };
+use bytemuck::NoUninit;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
@@ -360,4 +361,12 @@ pub trait GPUOperation: Operation {
             debug_buffer,
         ))
     }
+}
+
+pub trait CPUOperation: Operation {
+    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError>;
+}
+
+pub(crate) fn cpu_store_result<T: NoUninit>(dst: &Tensor, data: &[T]) {
+    dst.update_storage(Storage::CPU(CPUBuffer::from_slice(data, dst.shape())));
 }

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -197,9 +197,7 @@ impl Binary {
     fn add(&self, dst: Tensor) -> Result<Tensor, OperationError> {
         let mut lhs = self.lhs.to_vec::<f32>()?;
         let rhs = self.rhs.to_vec::<f32>()?;
-        for i in 0..dst.shape().numel() {
-            lhs[i] += rhs[i];
-        }
+        (0..dst.shape().numel()).for_each(|i| lhs[i] += rhs[i]);
         cpu_store_result(&dst, &lhs);
         Ok(dst)
     }
@@ -207,9 +205,7 @@ impl Binary {
     fn sub(&self, dst: Tensor) -> Result<Tensor, OperationError> {
         let mut lhs = self.lhs.to_vec::<f32>()?;
         let rhs = self.rhs.to_vec::<f32>()?;
-        for i in 0..dst.shape().numel() {
-            lhs[i] -= rhs[i];
-        }
+        (0..dst.shape().numel()).for_each(|i| lhs[i] -= rhs[i]);
         cpu_store_result(&dst, &lhs);
         Ok(dst)
     }
@@ -217,9 +213,7 @@ impl Binary {
     fn mul(&self, dst: Tensor) -> Result<Tensor, OperationError> {
         let mut lhs = self.lhs.to_vec::<f32>()?;
         let rhs = self.rhs.to_vec::<f32>()?;
-        for i in 0..dst.shape().numel() {
-            lhs[i] *= rhs[i];
-        }
+        (0..dst.shape().numel()).for_each(|i| lhs[i] *= rhs[i]);
         cpu_store_result(&dst, &lhs);
         Ok(dst)
     }
@@ -227,9 +221,7 @@ impl Binary {
     fn div(&self, dst: Tensor) -> Result<Tensor, OperationError> {
         let mut lhs = self.lhs.to_vec::<f32>()?;
         let rhs = self.rhs.to_vec::<f32>()?;
-        for i in 0..dst.shape().numel() {
-            lhs[i] /= rhs[i];
-        }
+        (0..dst.shape().numel()).for_each(|i| lhs[i] /= rhs[i]);
         cpu_store_result(&dst, &lhs);
         Ok(dst)
     }

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -118,6 +118,14 @@ impl Binary {
     pub fn op(&self) -> &BinaryOp {
         &self.op
     }
+
+    pub fn lhs(&self) -> &Tensor {
+        &self.lhs
+    }
+
+    pub fn rhs(&self) -> &Tensor {
+        &self.rhs
+    }
 }
 
 #[derive(Debug, ShaderType, WgslMetadata)]
@@ -261,41 +269,6 @@ impl Kernel for BinaryKernels {
                 inner.lhs.dt(),
                 kernel_element
             ))),
-        }
-    }
-}
-
-impl Binary {
-    // TODO: Support all dtypes
-    // TODO: Avoid polluting the namespace with these functions. Use wrapping type.
-    fn add(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a + b)?;
-        Ok(dst)
-    }
-
-    fn sub(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a - b)?;
-        Ok(dst)
-    }
-
-    fn mul(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a * b)?;
-        Ok(dst)
-    }
-
-    fn div(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a / b)?;
-        Ok(dst)
-    }
-}
-
-impl CPUOperation for Binary {
-    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        match self.op {
-            BinaryOp::Add => self.add(dst),
-            BinaryOp::Sub => self.sub(dst),
-            BinaryOp::Mul => self.mul(dst),
-            BinaryOp::Div => self.div(dst),
         }
     }
 }

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -5,7 +5,7 @@ use inline_wgsl::wgsl;
 use ratchet_macros::WgslMetadata;
 
 use crate::{
-    cpu_store_result,
+    binary_apply_inplace, cpu_store_result,
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
     rvec, Array, BindingMode, BuiltIn, CPUOperation, DType, GPUOperation, InvariantError, Kernel,
     KernelElement, KernelRenderable, KernelSource, OpGuards, Operation, OperationError, RVec,
@@ -278,34 +278,22 @@ impl CPUOperation for Binary {
 
 impl Binary {
     fn add(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] += rhs[i]);
-        cpu_store_result(&dst, &lhs);
+        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a + b)?;
         Ok(dst)
     }
 
     fn sub(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] -= rhs[i]);
-        cpu_store_result(&dst, &lhs);
+        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a - b)?;
         Ok(dst)
     }
 
     fn mul(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] *= rhs[i]);
-        cpu_store_result(&dst, &lhs);
+        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a * b)?;
         Ok(dst)
     }
 
     fn div(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] /= rhs[i]);
-        cpu_store_result(&dst, &lhs);
+        binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a / b)?;
         Ok(dst)
     }
 }

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -182,51 +182,6 @@ impl GPUOperation for Binary {
     }
 }
 
-impl CPUOperation for Binary {
-    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        match self.op {
-            BinaryOp::Add => self.add(dst),
-            BinaryOp::Sub => self.sub(dst),
-            BinaryOp::Mul => self.mul(dst),
-            BinaryOp::Div => self.div(dst),
-        }
-    }
-}
-
-impl Binary {
-    fn add(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] += rhs[i]);
-        cpu_store_result(&dst, &lhs);
-        Ok(dst)
-    }
-
-    fn sub(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] -= rhs[i]);
-        cpu_store_result(&dst, &lhs);
-        Ok(dst)
-    }
-
-    fn mul(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] *= rhs[i]);
-        cpu_store_result(&dst, &lhs);
-        Ok(dst)
-    }
-
-    fn div(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        let mut lhs = self.lhs.to_vec::<f32>()?;
-        let rhs = self.rhs.to_vec::<f32>()?;
-        (0..dst.shape().numel()).for_each(|i| lhs[i] /= rhs[i]);
-        cpu_store_result(&dst, &lhs);
-        Ok(dst)
-    }
-}
-
 pub enum BinaryKernels {
     Standard(Binary),
 }
@@ -307,6 +262,51 @@ impl Kernel for BinaryKernels {
                 kernel_element
             ))),
         }
+    }
+}
+
+impl CPUOperation for Binary {
+    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+        match self.op {
+            BinaryOp::Add => self.add(dst),
+            BinaryOp::Sub => self.sub(dst),
+            BinaryOp::Mul => self.mul(dst),
+            BinaryOp::Div => self.div(dst),
+        }
+    }
+}
+
+impl Binary {
+    fn add(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+        let mut lhs = self.lhs.to_vec::<f32>()?;
+        let rhs = self.rhs.to_vec::<f32>()?;
+        (0..dst.shape().numel()).for_each(|i| lhs[i] += rhs[i]);
+        cpu_store_result(&dst, &lhs);
+        Ok(dst)
+    }
+
+    fn sub(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+        let mut lhs = self.lhs.to_vec::<f32>()?;
+        let rhs = self.rhs.to_vec::<f32>()?;
+        (0..dst.shape().numel()).for_each(|i| lhs[i] -= rhs[i]);
+        cpu_store_result(&dst, &lhs);
+        Ok(dst)
+    }
+
+    fn mul(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+        let mut lhs = self.lhs.to_vec::<f32>()?;
+        let rhs = self.rhs.to_vec::<f32>()?;
+        (0..dst.shape().numel()).for_each(|i| lhs[i] *= rhs[i]);
+        cpu_store_result(&dst, &lhs);
+        Ok(dst)
+    }
+
+    fn div(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+        let mut lhs = self.lhs.to_vec::<f32>()?;
+        let rhs = self.rhs.to_vec::<f32>()?;
+        (0..dst.shape().numel()).for_each(|i| lhs[i] /= rhs[i]);
+        cpu_store_result(&dst, &lhs);
+        Ok(dst)
     }
 }
 

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -265,18 +265,9 @@ impl Kernel for BinaryKernels {
     }
 }
 
-impl CPUOperation for Binary {
-    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        match self.op {
-            BinaryOp::Add => self.add(dst),
-            BinaryOp::Sub => self.sub(dst),
-            BinaryOp::Mul => self.mul(dst),
-            BinaryOp::Div => self.div(dst),
-        }
-    }
-}
-
 impl Binary {
+    // TODO: Support all dtypes
+    // TODO: Avoid polluting the namespace with these functions. Use wrapping type.
     fn add(&self, dst: Tensor) -> Result<Tensor, OperationError> {
         binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a + b)?;
         Ok(dst)
@@ -295,6 +286,17 @@ impl Binary {
     fn div(&self, dst: Tensor) -> Result<Tensor, OperationError> {
         binary_apply_inplace::<f32>(&self.lhs, &self.rhs, &dst, |a, b| a / b)?;
         Ok(dst)
+    }
+}
+
+impl CPUOperation for Binary {
+    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
+        match self.op {
+            BinaryOp::Add => self.add(dst),
+            BinaryOp::Sub => self.sub(dst),
+            BinaryOp::Mul => self.mul(dst),
+            BinaryOp::Div => self.div(dst),
+        }
     }
 }
 

--- a/crates/ratchet-core/src/ops/cast.rs
+++ b/crates/ratchet-core/src/ops/cast.rs
@@ -6,7 +6,7 @@ use inline_wgsl::wgsl;
 use ratchet_macros::WgslMetadata;
 
 use crate::{
-    cpu::{apply_fn, cpu_store_result},
+    cpu::{cpu_store_result, unary_apply_fn},
     gpu::BindGroupLayoutDescriptor,
     rvec, Array, BindingMode, BuiltIn, CPUOperation, DType, GPUOperation, Kernel, KernelElement,
     KernelRenderable, KernelSource, OpGuards, Operation, OperationError, RVec, Scalar, StorageView,
@@ -225,16 +225,20 @@ impl CPUOperation for Cast {
         }
         match (self.input.dt(), self.dst_dt) {
             // F32 ->
-            (DType::F32, DType::F16) => apply_fn::<f32, f16>(&self.input, &dst, f16::from_f32)?,
-            (DType::F32, DType::BF16) => apply_fn::<f32, bf16>(&self.input, &dst, bf16::from_f32)?,
+            (DType::F32, DType::F16) => {
+                unary_apply_fn::<f32, f16>(&self.input, &dst, f16::from_f32)?
+            }
+            (DType::F32, DType::BF16) => {
+                unary_apply_fn::<f32, bf16>(&self.input, &dst, bf16::from_f32)?
+            }
             (DType::F32, DType::I32) => direct_cast::<f32, i32>(&self.input, &dst)?,
             (DType::F32, DType::U32) => direct_cast::<f32, u32>(&self.input, &dst)?,
 
             // F16 ->
-            (DType::F16, DType::F32) => apply_fn::<f16, f32>(&self.input, &dst, f32::from)?,
+            (DType::F16, DType::F32) => unary_apply_fn::<f16, f32>(&self.input, &dst, f32::from)?,
 
             // BF16 ->
-            (DType::BF16, DType::F32) => apply_fn::<bf16, f32>(&self.input, &dst, f32::from)?,
+            (DType::BF16, DType::F32) => unary_apply_fn::<bf16, f32>(&self.input, &dst, f32::from)?,
 
             // I32 ->
             (DType::I32, DType::F32) => direct_cast::<i32, f32>(&self.input, &dst)?,

--- a/crates/ratchet-core/src/ops/cast.rs
+++ b/crates/ratchet-core/src/ops/cast.rs
@@ -20,6 +20,16 @@ pub struct Cast {
     dst_dt: DType,
 }
 
+impl Cast {
+    pub fn input(&self) -> &Tensor {
+        &self.input
+    }
+
+    pub fn dst_dt(&self) -> DType {
+        self.dst_dt
+    }
+}
+
 impl KernelRenderable for CastKernels {
     fn register_bindings<SP: WgslPrimitive>(
         &self,
@@ -204,52 +214,6 @@ impl Kernel for CastKernels {
             }
             _ => unimplemented!("Cannot cast {:?} -> {:?}", inner.input.dt(), inner.dst_dt),
         }
-    }
-}
-
-fn direct_cast<T: TensorDType, U: TensorDType>(
-    input: &Tensor,
-    dst: &Tensor,
-) -> Result<(), OperationError> {
-    let input = input.to_vec::<T>()?;
-    let result =
-        bytemuck::try_cast_slice::<T, U>(&input).map_err(|_| anyhow!("Failed direct cast"))?;
-    cpu_store_result(dst, &result);
-    Ok(())
-}
-
-impl CPUOperation for Cast {
-    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        if self.input.dt() == self.dst_dt {
-            return Ok(self.input.clone());
-        }
-        match (self.input.dt(), self.dst_dt) {
-            // F32 ->
-            (DType::F32, DType::F16) => {
-                unary_apply_fn::<f32, f16>(&self.input, &dst, f16::from_f32)?
-            }
-            (DType::F32, DType::BF16) => {
-                unary_apply_fn::<f32, bf16>(&self.input, &dst, bf16::from_f32)?
-            }
-            (DType::F32, DType::I32) => direct_cast::<f32, i32>(&self.input, &dst)?,
-            (DType::F32, DType::U32) => direct_cast::<f32, u32>(&self.input, &dst)?,
-
-            // F16 ->
-            (DType::F16, DType::F32) => unary_apply_fn::<f16, f32>(&self.input, &dst, f32::from)?,
-
-            // BF16 ->
-            (DType::BF16, DType::F32) => unary_apply_fn::<bf16, f32>(&self.input, &dst, f32::from)?,
-
-            // I32 ->
-            (DType::I32, DType::F32) => direct_cast::<i32, f32>(&self.input, &dst)?,
-
-            // U32 ->
-            (DType::U32, DType::F32) => direct_cast::<u32, f32>(&self.input, &dst)?,
-
-            _ => unimplemented!("Cannot cast {:?} -> {:?}", self.input.dt(), self.dst_dt),
-        };
-
-        Ok(dst)
     }
 }
 

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -6,8 +6,6 @@ use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
 use ratchet_macros::WgslMetadata;
-
-use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use crate::{
@@ -407,7 +405,7 @@ def {}(a):
     }
 
     fn run_unary_trial(prob: UnaryProblem) -> anyhow::Result<()> {
-        let device = Device::request_device(DeviceRequest::GPU).unwrap();
+        let device = Device::request_device(DeviceRequest::CPU).unwrap();
         let UnaryProblem { op, B, M, N } = prob;
         println!("op: {:?}, B: {}, M: {}, N: {}", op, B, M, N);
         let a = Tensor::randn::<f32>(shape![B, M], Device::CPU);
@@ -419,6 +417,7 @@ def {}(a):
         let ground = ground_truth(&a, &op, args)?;
 
         let a_gpu = a.to(&device)?;
+        let a_gpu = a;
         let c_gpu = match op {
             UnaryOp::Gelu => a_gpu.gelu()?,
             UnaryOp::Tanh => a_gpu.tanh()?,

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -360,7 +360,7 @@ impl Kernel for UnaryKernels {
 
 impl CPUOperation for Unary {
     fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        todo!()
+        Ok(dst)
         /*
         match self.op {
             UnaryOp::Gelu => self.gelu(dst),
@@ -378,7 +378,7 @@ impl CPUOperation for Unary {
             UnaryOp::Silu => self.silu(dst),
             UnaryOp::Sigmoid => self.sigmoid(dst),
         }
-        */
+         */
     }
 }
 

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -10,9 +10,10 @@ use strum_macros::EnumIter;
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
-    rvec, Array, BindingMode, BuiltIn, CPUOperation, DType, GPUOperation, Kernel, KernelElement,
-    KernelRenderable, KernelSource, OpGuards, Operation, OperationError, RVec, Scalar, StorageView,
-    Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
+    rvec, unary_apply_fn, Array, BindingMode, BuiltIn, CPUOperation, DType, GPUOperation, Kernel,
+    KernelElement, KernelRenderable, KernelSource, OpGuards, Operation, OperationError, RVec,
+    Scalar, StorageView, Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize,
+    Workload,
 };
 
 #[cfg(test)]
@@ -164,6 +165,10 @@ impl Unary {
 
     pub fn op(&self) -> &UnaryOp {
         &self.op
+    }
+
+    pub fn input(&self) -> &Tensor {
+        &self.input
     }
 
     fn render_gelu<P: WgslPrimitive>() -> String {
@@ -355,30 +360,6 @@ impl Kernel for UnaryKernels {
         Ok(UnaryMeta {
             numel: dst.shape().numel() as u32,
         })
-    }
-}
-
-impl CPUOperation for Unary {
-    fn apply(&self, dst: Tensor) -> Result<Tensor, OperationError> {
-        Ok(dst)
-        /*
-        match self.op {
-            UnaryOp::Gelu => self.gelu(dst),
-            UnaryOp::Tanh => self.tanh(dst),
-            UnaryOp::Exp => self.exp(dst),
-            UnaryOp::Log => self.log(dst),
-            UnaryOp::Sin => self.sin(dst),
-            UnaryOp::Cos => self.cos(dst),
-            UnaryOp::Abs => self.abs(dst),
-            UnaryOp::Sqrt => self.sqrt(dst),
-            UnaryOp::Relu => self.relu(dst),
-            UnaryOp::Floor => self.floor(dst),
-            UnaryOp::Ceil => self.ceil(dst),
-            UnaryOp::Neg => self.neg(dst),
-            UnaryOp::Silu => self.silu(dst),
-            UnaryOp::Sigmoid => self.sigmoid(dst),
-        }
-         */
     }
 }
 

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1,8 +1,9 @@
 use crate::gpu::{BindGroupEntry, CpuUniform, WgpuDevice};
 use crate::{
-    apply_binary, apply_unary, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp,
-    DType, Device, DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp,
-    Operation, OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
+    apply_binary, apply_cast, apply_unary, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation,
+    CompiledOp, DType, Device, DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError,
+    LazyOp, Operation, OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType,
+    TensorId,
 };
 use derive_new::new;
 use npyz::WriterBuilder;
@@ -743,7 +744,7 @@ impl Tensor {
     pub fn cpu_apply(self, dst: Tensor) -> Option<Tensor> {
         match self.op().clone() {
             LazyOp::Binary(b) => apply_binary(b, dst).ok(),
-            LazyOp::Cast(c) => c.apply(dst).ok(),
+            LazyOp::Cast(c) => apply_cast(c, dst).ok(),
             LazyOp::Matmul(m) => todo!(),
             LazyOp::Softmax(s) => todo!(),
             LazyOp::RoPE(r) => todo!(),

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1,9 +1,8 @@
 use crate::gpu::{BindGroupEntry, CpuUniform, WgpuDevice};
 use crate::{
-    apply_binary, apply_cast, apply_unary, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation,
-    CompiledOp, DType, Device, DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError,
-    LazyOp, Operation, OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType,
-    TensorId,
+    cpu::*, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp, DType, Device,
+    DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp, Operation,
+    OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
 };
 use derive_new::new;
 use npyz::WriterBuilder;
@@ -743,17 +742,17 @@ impl Tensor {
 
     pub fn cpu_apply(self, dst: Tensor) -> Option<Tensor> {
         match self.op().clone() {
-            LazyOp::Binary(b) => apply_binary(b, dst).ok(),
-            LazyOp::Cast(c) => apply_cast(c, dst).ok(),
+            LazyOp::Binary(b) => cpu_binary(b, dst).ok(),
+            LazyOp::Cast(c) => cpu_cast(c, dst).ok(),
             LazyOp::Matmul(m) => todo!(),
             LazyOp::Softmax(s) => todo!(),
             LazyOp::RoPE(r) => todo!(),
-            LazyOp::Unary(u) => apply_unary(u, dst).ok(),
+            LazyOp::Unary(u) => cpu_unary(u, dst).ok(),
             LazyOp::Reindex(r) => todo!(),
             LazyOp::Concat(c) => todo!(),
             LazyOp::Norm(n) => todo!(),
             LazyOp::Conv(c) => todo!(),
-            LazyOp::Select(i) => todo!(),
+            LazyOp::Select(i) => cpu_index_select(i, dst).ok(),
             LazyOp::IndexWrite(i) => todo!(),
             LazyOp::Cache(c) => todo!(),
             LazyOp::Const => None,

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -748,7 +748,7 @@ impl Tensor {
             LazyOp::Matmul(m) => todo!(),
             LazyOp::Softmax(s) => todo!(),
             LazyOp::RoPE(r) => todo!(),
-            LazyOp::Unary(u) => todo!(),
+            LazyOp::Unary(u) => u.apply(dst).ok(),
             LazyOp::Reindex(r) => todo!(),
             LazyOp::Concat(c) => todo!(),
             LazyOp::Norm(n) => todo!(),

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1,12 +1,12 @@
 use crate::gpu::{BindGroupEntry, CpuUniform, WgpuDevice};
 use crate::{
-    ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp, DType, Device, DeviceRequest,
+    apply_unary, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp, DType, Device,
     DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp, Operation,
     OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
 };
 use derive_new::new;
 use npyz::WriterBuilder;
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use parking_lot::{RwLock, RwLockReadGuard};
 use std::collections::HashSet;
 use std::io::{BufRead, Seek};
 use std::ops::Bound;
@@ -740,15 +740,14 @@ impl Tensor {
         }
     }
 
-    pub fn cpu_apply(&self, dst: Tensor) -> Option<Tensor> {
-        use CPUOperation;
-        match self.op() {
+    pub fn cpu_apply(self, dst: Tensor) -> Option<Tensor> {
+        match self.op().clone() {
             LazyOp::Binary(b) => b.apply(dst).ok(),
             LazyOp::Cast(c) => c.apply(dst).ok(),
             LazyOp::Matmul(m) => todo!(),
             LazyOp::Softmax(s) => todo!(),
             LazyOp::RoPE(r) => todo!(),
-            LazyOp::Unary(u) => u.apply(dst).ok(),
+            LazyOp::Unary(u) => apply_unary(u, dst).ok(),
             LazyOp::Reindex(r) => todo!(),
             LazyOp::Concat(c) => todo!(),
             LazyOp::Norm(n) => todo!(),

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -744,7 +744,7 @@ impl Tensor {
         use CPUOperation;
         match self.op() {
             LazyOp::Binary(b) => b.apply(dst).ok(),
-            LazyOp::Cast(c) => todo!(),
+            LazyOp::Cast(c) => c.apply(dst).ok(),
             LazyOp::Matmul(m) => todo!(),
             LazyOp::Softmax(s) => todo!(),
             LazyOp::RoPE(r) => todo!(),

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1,8 +1,8 @@
 use crate::gpu::{BindGroupEntry, CpuUniform, WgpuDevice};
 use crate::{
-    apply_unary, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp, DType, Device,
-    DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp, Operation,
-    OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
+    apply_binary, apply_unary, ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp,
+    DType, Device, DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp,
+    Operation, OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
 };
 use derive_new::new;
 use npyz::WriterBuilder;
@@ -742,7 +742,7 @@ impl Tensor {
 
     pub fn cpu_apply(self, dst: Tensor) -> Option<Tensor> {
         match self.op().clone() {
-            LazyOp::Binary(b) => b.apply(dst).ok(),
+            LazyOp::Binary(b) => apply_binary(b, dst).ok(),
             LazyOp::Cast(c) => c.apply(dst).ok(),
             LazyOp::Matmul(m) => todo!(),
             LazyOp::Softmax(s) => todo!(),

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1,12 +1,12 @@
 use crate::gpu::{BindGroupEntry, CpuUniform, WgpuDevice};
 use crate::{
-    ops::*, rvec, BufferSegment, CPUBuffer, CompiledOp, DType, Device, DeviceStorage, Executable,
-    GPUBuffer, GPUOperation, InvariantError, LazyOp, Operation, OperationError, RVec, RawCPUBuffer,
-    Shape, Storage, Strides, TensorDType, TensorId,
+    ops::*, rvec, BufferSegment, CPUBuffer, CPUOperation, CompiledOp, DType, Device, DeviceRequest,
+    DeviceStorage, Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp, Operation,
+    OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
 };
 use derive_new::new;
 use npyz::WriterBuilder;
-use parking_lot::{RwLock, RwLockReadGuard};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::HashSet;
 use std::io::{BufRead, Seek};
 use std::ops::Bound;
@@ -76,7 +76,7 @@ impl Tensor {
         Arc::strong_count(&self.inner)
     }
 
-    fn update_storage(&self, storage: Storage) {
+    pub(crate) fn update_storage(&self, storage: Storage) {
         *self.inner.storage.write() = Some(storage);
     }
 }
@@ -648,7 +648,7 @@ impl Tensor {
             })
     }
 
-    /// # Segments  
+    /// # Segments
     ///
     /// In Ratchet, a tensor may be split into multiple segments.
     /// This is due to our quantization scheme allowing multiple quantized components to be packed
@@ -740,15 +740,61 @@ impl Tensor {
         }
     }
 
-    fn resolve_inner(self, debug: bool) -> Result<Tensor, TensorError> {
-        let mut uniform = CpuUniform::new();
-        let device = self.device().try_gpu()?;
-        device.begin_pass();
+    pub fn cpu_apply(&self, dst: Tensor) -> Option<Tensor> {
+        use CPUOperation;
+        match self.op() {
+            LazyOp::Binary(b) => b.apply(dst).ok(),
+            LazyOp::Cast(c) => todo!(),
+            LazyOp::Matmul(m) => todo!(),
+            LazyOp::Softmax(s) => todo!(),
+            LazyOp::RoPE(r) => todo!(),
+            LazyOp::Unary(u) => todo!(),
+            LazyOp::Reindex(r) => todo!(),
+            LazyOp::Concat(c) => todo!(),
+            LazyOp::Norm(n) => todo!(),
+            LazyOp::Conv(c) => todo!(),
+            LazyOp::Select(i) => todo!(),
+            LazyOp::IndexWrite(i) => todo!(),
+            LazyOp::Cache(c) => todo!(),
+            LazyOp::Const => None,
+            LazyOp::View(_) => None,
+        }
+    }
 
+    fn resolve_inner(self, debug: bool) -> Result<Tensor, TensorError> {
+        match self.device().clone() {
+            Device::CPU => {
+                return self.resolve_cpu(debug);
+            }
+            Device::GPU(device) => {
+                return self.resolve_gpu(&device, debug);
+            }
+        }
+    }
+
+    fn resolve_cpu(self, debug: bool) -> Result<Tensor, TensorError> {
+        let mut tensor = self.clone();
         let execution_order = self.execution_order();
 
+        for t in execution_order.into_iter() {
+            log::debug!("Running: {:?}", t.op().name());
+            assert!(t.device().is_cpu());
+            if t.resolved() {
+                continue;
+            }
+            tensor = tensor.cpu_apply(t.clone()).unwrap();
+        }
+
+        Ok(tensor.clone())
+    }
+
+    fn resolve_gpu(self, gpu_device: &WgpuDevice, debug: bool) -> Result<Tensor, TensorError> {
+        let execution_order = self.execution_order();
+        let mut uniform = CpuUniform::new();
         let mut compiled_ops = Vec::with_capacity(execution_order.len());
-        let mut allocations = device.allocate_cfg(&execution_order, device)?;
+
+        gpu_device.begin_pass();
+        let mut allocations = gpu_device.allocate_cfg(&execution_order, gpu_device)?;
 
         #[cfg(feature = "plotting")]
         crate::plot::render_to_file(execution_order.last().unwrap(), "prealloc.svg").unwrap();
@@ -773,7 +819,7 @@ impl Tensor {
             let to_modify = t.op().srcs()[0];
             let can_inplace = t.op().supports_inplace() && to_modify.strong_count() == 1;
 
-            if let Some(compiled_op) = t.compile_gpu(&mut uniform, device, can_inplace, debug) {
+            if let Some(compiled_op) = t.compile_gpu(&mut uniform, gpu_device, can_inplace, debug) {
                 compiled_ops.push(compiled_op);
                 #[cfg(feature = "debug")]
                 compute_dsts.push(*t);
@@ -786,7 +832,7 @@ impl Tensor {
 
         let executable = Executable::new(
             compiled_ops,
-            uniform.into_gpu(device)?,
+            uniform.into_gpu(gpu_device)?,
             #[cfg(feature = "debug")]
             compute_dsts,
         );
@@ -802,8 +848,9 @@ impl Tensor {
             executable.dispatch(device).unwrap()
         };
         #[cfg(not(feature = "debug"))]
-        let index = executable.dispatch(device).unwrap();
-        device.poll(wgpu::MaintainBase::WaitForSubmissionIndex(index));
+        let index = executable.dispatch(gpu_device).unwrap();
+        gpu_device.poll(wgpu::MaintainBase::WaitForSubmissionIndex(index));
+
         Ok(self)
     }
 

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -764,7 +764,7 @@ impl Tensor {
     fn resolve_inner(self, debug: bool) -> Result<Tensor, TensorError> {
         match self.device().clone() {
             Device::CPU => {
-                return self.resolve_cpu(debug);
+                return self.resolve_cpu();
             }
             Device::GPU(device) => {
                 return self.resolve_gpu(&device, debug);
@@ -772,7 +772,7 @@ impl Tensor {
         }
     }
 
-    fn resolve_cpu(self, debug: bool) -> Result<Tensor, TensorError> {
+    fn resolve_cpu(self) -> Result<Tensor, TensorError> {
         let mut tensor = self.clone();
         let execution_order = self.execution_order();
 

--- a/crates/ratchet-loader/src/lib.rs
+++ b/crates/ratchet-loader/src/lib.rs
@@ -140,38 +140,3 @@ impl GgmlDType {
         numel * self.type_size() / self.block_numel()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::gguf::gguf::Header;
-    use half::f16;
-    use ratchet::{shape, Device, DeviceRequest, Tensor};
-
-    #[test]
-    fn test_q4_dequant() -> anyhow::Result<()> {
-        let _ = env_logger::builder().is_test(true).try_init();
-        let model_path = "../../fixtures/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf";
-        let mut reader = std::io::BufReader::new(std::fs::File::open(model_path)?);
-        let device = Device::request_device(DeviceRequest::GPU)?;
-        let content = Header::read(&mut reader)?;
-        let t = content.tensor(&mut reader, "blk.0.attn_k.weight", &device)?;
-
-        let rhs = Tensor::randn::<f16>(shape![2048, 2048], device.clone());
-        let out = t.matmul(rhs, false, false)?.resolve()?;
-        let out_cpu = out.to(&Device::CPU)?;
-
-        println!("{:#?}", out_cpu);
-
-        let ground = "../../fixtures/tinyllama_blk_0_attn_k_weight_f32.npy";
-        let ground_t = Tensor::read_npy::<f32, _>(ground, &device)?
-            .half()?
-            .resolve()?
-            .to(&Device::CPU)?;
-
-        println!("{:#?}", ground_t);
-
-        //out_cpu.all_close(&ground_t, f16::from_f32(1e-3), f16::from_f32(1e-3))?;
-
-        Ok(())
-    }
-}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Initial steps adding CPU implementation for ratchet.

todo:
- [x] Simple POC
- [x] Figure out a decent pattern that allows us to support all dtypes

Ops implemented in this first PR:
  - Binary
  - Cast
  - Unary
  - Select
  
Currently we are using `Tensor::to_vec<T>` to access the data in the cpu buffer. At some point we should look into "peeking" into the storage as a slice instead. Probably at the same time as introducing vectorized operations and wasm.