### PR TITLE
Nextest slow tests timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = "2m"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,2 @@
 [profile.default]
-slow-timeout = "2m"
+slow-timeout = { period = "60s", terminate-after = 2 }


### PR DESCRIPTION
Yay it works 🎉 
```bash
       SLOW [> 60.000s] ratchet-models whisper::decoder::tests::decoder_matches
TERMINATING [>120.000s] ratchet-models whisper::decoder::tests::decoder_matches
    TIMEOUT [ 120.018s] ratchet-models whisper::decoder::tests::decoder_matches
```