### PR TITLE
fix: reduce dependencies

### DIFF
--- a/crates/ratchet-cli/Cargo.toml
+++ b/crates/ratchet-cli/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { workspace = true }
 env_logger = { workspace = true }
 fern = { workspace = true }
 chrono = { workspace = true }
-tokenizers = { workspace = true } 
+tokenizers = { workspace = true, default-features = false } 
 ndarray = { workspace = true }
 ndarray-stats = { workspace = true }
 anyhow.workspace = true

--- a/crates/ratchet-loader/Cargo.toml
+++ b/crates/ratchet-loader/Cargo.toml
@@ -13,8 +13,6 @@ anyhow.workspace = true
 bytemuck.workspace = true
 thiserror.workspace = true
 log.workspace = true
-itertools = { workspace = true }
-env_logger.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.84"

--- a/crates/ratchet-nn/Cargo.toml
+++ b/crates/ratchet-nn/Cargo.toml
@@ -19,4 +19,4 @@ proptest = { workspace = true }
 test-strategy = { workspace = true }
 hf-hub = { workspace = true }
 ratchet-loader = { path = "../ratchet-loader" }
-tokenizers.workspace = true
+tokenizers = { workspace = true, default-features = false }


### PR DESCRIPTION
Closes #170.

Removes unused ratchet-loader dependencies and disables default tokenizer features where only inference-time load/encode/decode APIs are used.